### PR TITLE
lexer: reworked lexer to use bytes as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ the overall performance as well as the full results of
 
 | JSON size | `encoding/json` | `libjson` |
 | --------- | --------------- | --------- |
+| 1MB       | 12.4ms          | 12.0ms    |
+| 5MB       | 59.6ms          | 50ms      |
+| 10MB      | 115.0ms         | 96ms      |
+
+- use `[]byte` as source for lexer instead of `bufio.Reader`
+- thus use slicing into the original array instead of copying bytes for numbers
+  and strings
+- inline comparison for `null`, `false` and `true`, saves 3, 4 and 3
+  `lexer.advance` invocations, replaces them with direct byte slice access and
+  comparison
+
+This change allowed for the omission of memory allocations for every byte
+collected for number and string processing. Instead of doing so, this change
+enables the usage of sub slices of the original data and thus does not create
+new memory until the parser processes the string or number - resulting in 0.4ms
+faster execution for 1MB, 10ms for 5MB and 21ms for 10MB JSON inputs.
+
+### [a36a1bd](https://github.com/xNaCly/libjson/commit/a36a1bd042b10ce779c95c7c1e52232cf8d16fab)
+
+| JSON size | `encoding/json` | `libjson` |
+| --------- | --------------- | --------- |
 | 1MB       | 12.0ms          | 13.4ms    |
 | 5MB       | 58.4ms          | 66.3ms    |
 | 10MB      | 114.0ms         | 127.0ms   |

--- a/json.go
+++ b/json.go
@@ -1,13 +1,15 @@
 package libjson
 
 import (
-	"bufio"
 	"io"
-	"strings"
 )
 
 func NewReader(r io.Reader) (*JSON, error) {
-	p := parser{l: lexer{r: bufio.NewReader(r)}}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	p := parser{l: lexer{data: data}}
 	obj, err := p.parse()
 	if err != nil {
 		return nil, err
@@ -15,6 +17,11 @@ func NewReader(r io.Reader) (*JSON, error) {
 	return &JSON{obj}, nil
 }
 
-func New(s string) (*JSON, error) {
-	return NewReader(strings.NewReader(s))
+func New(data []byte) (*JSON, error) {
+	p := parser{l: lexer{data: data}}
+	obj, err := p.parse()
+	if err != nil {
+		return nil, err
+	}
+	return &JSON{obj}, nil
 }

--- a/lexer.go
+++ b/lexer.go
@@ -1,19 +1,27 @@
 package libjson
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
 )
 
 type lexer struct {
-	r   *bufio.Reader
-	buf []byte
+	data []byte
+	pos  int
+}
+
+func (l *lexer) advance() (byte, error) {
+	if l.pos >= len(l.data) {
+		return 0, io.EOF
+	}
+	cc := l.data[l.pos]
+	l.pos++
+	return cc, nil
 }
 
 func (l *lexer) next() (token, error) {
-	cc, err := l.r.ReadByte()
+	cc, err := l.advance()
 	if err != nil {
 		return empty, nil
 	}
@@ -21,7 +29,7 @@ func (l *lexer) next() (token, error) {
 	tt := t_eof
 
 	for cc == ' ' || cc == '\n' || cc == '\t' || cc == '\r' {
-		cc, err = l.r.ReadByte()
+		cc, err = l.advance()
 		if err != nil {
 			return empty, nil
 		}
@@ -41,67 +49,58 @@ func (l *lexer) next() (token, error) {
 	case ':':
 		tt = t_colon
 	case '"':
+		start := l.pos
+		end := start
 		for {
-			cc, err = l.r.ReadByte()
+			cc, err = l.advance()
 			if cc == '"' {
+				end = l.pos - 1
 				break
 			} else if err != nil {
 				return empty, errors.New("Unterminated string detected")
 			}
-			l.buf = append(l.buf, cc)
 		}
-		t := token{Type: t_string, Val: l.buf}
-		l.buf = make([]byte, 0, 8)
+		t := token{Type: t_string, Val: l.data[start:end]}
 		return t, nil
 	case 't': // this should always be the 'true' atom and is therefore optimised here
-		if b, err := l.r.ReadByte(); err != nil && b != 'r' {
+		if l.pos+3 > len(l.data) {
 			return empty, errors.New("Failed to read the expected 'true' atom")
 		}
-		if b, err := l.r.ReadByte(); err != nil && b != 'u' {
+		if !(l.data[l.pos] == 'r' && l.data[l.pos+1] == 'u' && l.data[l.pos+2] == 'e') {
 			return empty, errors.New("Failed to read the expected 'true' atom")
 		}
-		if b, err := l.r.ReadByte(); err != nil && b != 'e' {
-			return empty, errors.New("Failed to read the expected 'true' atom")
-		}
+		l.pos += 3
 		tt = t_true
 	case 'f': // this should always be the 'false' atom and is therefore optimised here
-		if b, err := l.r.ReadByte(); err != nil && b != 'a' {
+		if l.pos+4 > len(l.data) {
 			return empty, errors.New("Failed to read the expected 'false' atom")
 		}
-		if b, err := l.r.ReadByte(); err != nil && b != 'l' {
+		if !(l.data[l.pos] == 'a' && l.data[l.pos+1] == 'l' && l.data[l.pos+2] == 's' && l.data[l.pos+3] == 'e') {
 			return empty, errors.New("Failed to read the expected 'false' atom")
 		}
-		if b, err := l.r.ReadByte(); err != nil && b != 's' {
-			return empty, errors.New("Failed to read the expected 'false' atom")
-		}
-		if b, err := l.r.ReadByte(); err != nil && b != 'e' {
-			return empty, errors.New("Failed to read the expected 'false' atom")
-		}
+		l.pos += 4
 		tt = t_false
 	case 'n': // this should always be the 'null' atom and is therefore optimised here
-		if b, err := l.r.ReadByte(); err != nil && b != 'u' {
+		if l.pos+3 > len(l.data) {
 			return empty, errors.New("Failed to read the expected 'null' atom")
 		}
-		if b, err := l.r.ReadByte(); err != nil && b != 'l' {
+		if !(l.data[l.pos] == 'u' && l.data[l.pos+1] == 'l' && l.data[l.pos+2] == 'l') {
 			return empty, errors.New("Failed to read the expected 'null' atom")
 		}
-		if b, err := l.r.ReadByte(); err != nil && b != 'l' {
-			return empty, errors.New("Failed to read the expected 'null' atom")
-		}
+		l.pos += 3
 		tt = t_null
 	default:
 		if cc == '-' || (cc >= '0' && cc <= '9') {
-			l.buf = append(l.buf, cc)
-			cc, err = l.r.ReadByte()
+			start := l.pos - 1
+			cc, err = l.advance()
 			if err != nil {
 				// we hit eof here
-				return token{Type: t_number, Val: l.buf}, nil
+				return token{Type: t_number, Val: []byte{l.data[start]}}, nil
 			}
 
 			for {
 				if (cc >= '0' && cc <= '9') || cc == '-' || cc == '+' || cc == '.' || cc == 'e' || cc == 'E' {
-					l.buf = append(l.buf, cc)
-					cc, err = l.r.ReadByte()
+					cc, err = l.advance()
 					if err != nil {
 						break
 					}
@@ -109,13 +108,12 @@ func (l *lexer) next() (token, error) {
 					// the read at the start of the for loop iterates us too
 					// far, if we didnt break out of the loop but exited it
 					// according to its condition, thus we skip that here
-					l.r.UnreadByte()
+					l.pos--
 					break
 				}
 			}
 
-			t := token{Type: t_number, Val: l.buf}
-			l.buf = make([]byte, 0, 8)
+			t := token{Type: t_number, Val: l.data[start:l.pos]}
 			return t, nil
 		} else {
 			return empty, fmt.Errorf("Unexpected character %q at this position.", cc)
@@ -127,9 +125,13 @@ func (l *lexer) next() (token, error) {
 
 // lex is only intended for tests, use lexer.next() for production code
 func (l *lexer) lex(r io.Reader) ([]token, error) {
-	l.r = bufio.NewReader(r)
+	var err error
+	l.data, err = io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
 
-	toks := make([]token, 0, l.r.Size()/2)
+	toks := make([]token, 0, len(l.data)/2)
 	for {
 		if tok, err := l.next(); err == nil {
 			if tok.Type == t_eof {

--- a/object_test.go
+++ b/object_test.go
@@ -1,9 +1,7 @@
 package libjson
 
 import (
-	"bufio"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +23,7 @@ func TestObjectAtom(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i.inp+i.path, func(t *testing.T) {
-			obj, err := New(i.inp)
+			obj, err := New([]byte(i.inp))
 			assert.NoError(t, err)
 			assert.NotNil(t, obj)
 			out, err := obj.get(i.path)
@@ -38,7 +36,7 @@ func TestObjectAtom(t *testing.T) {
 // This tests the example in the readme, always copy from here to the readme
 func TestObjectReadme(t *testing.T) {
 	input := `{ "hello": {"world": ["hi"] } }`
-	jsonObj, _ := New(input) // or libjson.NewReader(r io.Reader)
+	jsonObj, _ := New([]byte(input)) // or libjson.NewReader(r io.Reader)
 
 	// accessing values
 	fmt.Println(Get[string](jsonObj, ".hello.world.0")) // hi
@@ -65,7 +63,7 @@ func TestStandardFail(t *testing.T) {
 	}
 	for _, i := range input {
 		t.Run(i, func(t *testing.T) {
-			p := parser{l: lexer{r: bufio.NewReader(strings.NewReader(i))}}
+			p := parser{l: lexer{data: []byte(i)}}
 			_, err := p.parse()
 			assert.Error(t, err)
 		})

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,9 +1,7 @@
 package libjson
 
 import (
-	"bufio"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +28,7 @@ func TestParserAtoms(t *testing.T) {
 	}
 	for i, in := range input {
 		t.Run(in, func(t *testing.T) {
-			p := &parser{l: lexer{r: bufio.NewReader(strings.NewReader(in))}}
+			p := &parser{l: lexer{data: []byte(in)}}
 			out, err := p.parse()
 			assert.NoError(t, err)
 			if !assert.EqualValues(t, wanted[i], out) {
@@ -55,7 +53,7 @@ func TestParserArray(t *testing.T) {
 	}
 	for i, in := range input {
 		t.Run(in, func(t *testing.T) {
-			p := &parser{l: lexer{r: bufio.NewReader(strings.NewReader(in))}}
+			p := &parser{l: lexer{data: []byte(in)}}
 			out, err := p.parse()
 			assert.NoError(t, err)
 			assert.EqualValues(t, wanted[i], out)
@@ -82,7 +80,7 @@ func TestParserObject(t *testing.T) {
 	}
 	for i, in := range input {
 		t.Run(in, func(t *testing.T) {
-			p := &parser{l: lexer{r: bufio.NewReader(strings.NewReader(in))}}
+			p := &parser{l: lexer{data: []byte(in)}}
 			out, err := p.parse()
 			assert.NoError(t, err)
 			assert.EqualValues(t, wanted[i], out)
@@ -109,7 +107,7 @@ func TestParserEdge(t *testing.T) {
 	}
 	for i, in := range input {
 		t.Run(in, func(t *testing.T) {
-			p := &parser{l: lexer{r: bufio.NewReader(strings.NewReader(in))}}
+			p := &parser{l: lexer{data: []byte(in)}}
 			out, err := p.parse()
 			assert.NoError(t, err)
 			assert.EqualValues(t, wanted[i], out)
@@ -143,7 +141,7 @@ func TestParserFail(t *testing.T) {
 	}
 	for _, in := range input {
 		t.Run(in, func(t *testing.T) {
-			p := &parser{l: lexer{r: bufio.NewReader(strings.NewReader(in))}}
+			p := &parser{l: lexer{data: []byte(in)}}
 			out, err := p.parse()
 			assert.Error(t, err)
 			assert.Nil(t, out)


### PR DESCRIPTION
this pr improves performance and surpasses the go implementation by 0.2ms for 1MB, 8ms for 5MB and 20ms for 10MB json sources, mainly because

- inlined null, true, false
- slice indexing for floats and strings instead of creating and inserting into buffers
- removal of reading from a Reader

## Todo:

- [x] document performance changes
- [x] document performance changes impact